### PR TITLE
feat(api)!: replace api singleton with createApi factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ We recommend using [Bun](https://bun.sh) to work with @auldrant/api.
 bun install
 ```
 
-## Usage
+## Quick start
 
 ```ts
-import { api } from '@auldrant/api';
+import { createApi } from '@auldrant/api';
+
+const api = createApi();
 
 const result = await api.get<User[]>('/api/users');
 if (result.ok) {
@@ -21,56 +23,145 @@ if (result.ok) {
 }
 ```
 
-## API
+## Configured instance
 
-### Method helpers
+Pass options to `createApi` to set defaults that apply to every request:
 
-All helpers return `Promise<ApiResponse<T>>`.
+```ts
+const api = createApi({
+  baseUrl: 'https://api.example.com',
+  headers: { Authorization: `Bearer ${token}` },
+  timeout: 5000,
+});
+
+// Relative paths are resolved against baseUrl
+const users = await api.get<User[]>('/users');
+```
+
+Per-request options always override instance defaults.
+
+## Method helpers
+
+All helpers are methods on the instance returned by `createApi` and return `Promise<ApiResponse<T>>`.
 
 | Method | Signature |
 |--------|-----------|
-| `api.get` | `(url, options?)` |
-| `api.post` | `(url, body?, options?)` |
-| `api.put` | `(url, body?, options?)` |
-| `api.patch` | `(url, body?, options?)` |
-| `api.delete` | `(url, options?)` |
-| `api.head` | `(url, options?)` |
-| `api.options` | `(url, options?)` |
+| `.get` | `(url, options?)` |
+| `.post` | `(url, body?, options?)` |
+| `.put` | `(url, body?, options?)` |
+| `.patch` | `(url, body?, options?)` |
+| `.delete` | `(url, options?)` |
+| `.head` | `(url, options?)` |
+| `.options` | `(url, options?)` |
 
 Plain objects passed as `body` are automatically serialized to JSON.
 
-### ApiResponse
+## ApiResponse
 
 ```ts
 type ApiResponse<T> =
-  | { ok: true;  data: T;    status: number }
-  | { ok: false; data: null; status: number };
+  | { ok: true;  data: T | null; status: number }
+  | { ok: false; data: null;     status: number };
 ```
 
-Use `ok` to narrow the type. Status `0` means a network error or aborted request.
+Use `ok` to narrow the type. Status `0` means a network error, timeout, or aborted request.
 
-### Options
+## Options reference
+
+### `RequestOptions` (GET, DELETE, HEAD, OPTIONS)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `accept` | `MimeType` | `MimeType.JSON` | Expected response MIME type |
+| `headers` | `HeadersInit` | — | Additional headers |
+| `signal` | `AbortSignal` | — | Cancel the request |
+| `timeout` | `number` | — | Abort after N milliseconds |
+| `retry` | `number` | `0` | Max additional attempts on network failure |
+| `retryDelay` | `number` | `0` | Milliseconds to wait between retries |
+
+### `RequestBodyOptions` (POST, PUT, PATCH)
+
+Extends `RequestOptions` with:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `contentType` | `MimeType` | `MimeType.JSON` | Request body content type |
+| `compression` | `CompressionMethod` | — | Compress the request body |
+
+### `ApiConfig` (createApi)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `baseUrl` | `string \| URL` | — | Prepended to all relative request paths |
+| `headers` | `HeadersInit` | — | Default headers for every request |
+| `accept` | `MimeType` | `MimeType.JSON` | Default Accept type for every request |
+| `timeout` | `number` | — | Default timeout for every request |
+
+## Timeout
 
 ```ts
-interface RequestOptions {
-  accept?: MimeType;      // Default: MimeType.JSON
-  headers?: HeadersInit;
-  signal?: AbortSignal;
-}
+// Per-request
+const result = await api.get('/data', { timeout: 3000 });
 
-interface RequestBodyOptions extends RequestOptions {
-  contentType?: MimeType;           // Default: MimeType.JSON
-  compression?: CompressionMethod;  // gzip or deflate
-}
+// Or set a default for all requests
+const api = createApi({ timeout: 5000 });
+const result = await api.get('/data'); // uses 5s timeout
 ```
 
-## Static Content
+Timed-out requests return `{ ok: false, status: 0 }`.
 
-All enums and types are re-exported from the package root:
+## Retry
 
-- `HttpMethod` — GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
-- `HttpStatus` — common HTTP status codes
-- `MimeType` — common MIME type strings
-- `CompressionMethod` — gzip, deflate
+Retries apply only to network failures (status 0). Server responses (4xx, 5xx) are never
+retried. The wait between attempts doubles on each retry (exponential backoff).
+
+```ts
+const result = await api.get('/data', {
+  retry: 3,         // up to 3 additional attempts
+  retryDelay: 500,  // 500ms → 1000ms → 2000ms
+});
+```
+
+## Abort
+
+```ts
+const controller = new AbortController();
+
+const result = await api.get('/slow', { signal: controller.signal });
+
+// Cancel from elsewhere
+controller.abort();
+```
+
+Aborted requests return `{ ok: false, status: 0 }`.
+
+## Compression
+
+Compress request bodies before sending (useful for large payloads):
+
+```ts
+const data = largeJsonPayload;
+
+await api.post('/ingest', data, {
+  compression: CompressionMethod.GZIP,
+});
+```
+
+`FormData` and `URLSearchParams` bodies are always passed through unchanged — the browser manages their encoding. Small payloads (under 1 KB) are skipped automatically.
+
+## Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `createApi` | function | Creates a configured API instance |
+| `ApiConfig` | type | Config object for `createApi` |
+| `ApiInstance` | type | Return type of `createApi` |
+| `ApiResponse` | type | Discriminated union response type |
+| `RequestOptions` | type | Options for GET/DELETE/HEAD/OPTIONS |
+| `RequestBodyOptions` | type | Options for POST/PUT/PATCH |
+| `HttpMethod` | enum | GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS |
+| `HttpStatus` | enum | Common HTTP status codes |
+| `MimeType` | enum | Common MIME type strings |
+| `CompressionMethod` | enum | gzip, deflate |
 
 [fetch]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,6 @@
 import {
+	type ApiConfig,
+	type ApiInstance,
 	type ApiResponse,
 	type CompressionMethod,
 	HttpMethod,
@@ -55,11 +57,17 @@ function compress(content: BodyInit, method?: CompressionMethod): BodyInit {
 function buildHeaders(
 	contentType: MimeType | undefined,
 	accept: MimeType,
-	compression: CompressionMethod | undefined,
-	extra: HeadersInit | undefined,
-	body: BodyInit | undefined
+	compression?: CompressionMethod,
+	configHeaders?: HeadersInit,
+	extraHeaders?: HeadersInit,
+	body?: BodyInit
 ): Headers {
-	const headers = new Headers(extra);
+	const headers = new Headers(configHeaders);
+	if (extraHeaders) {
+		new Headers(extraHeaders).forEach((v, k) => {
+			headers.set(k, v);
+		});
+	}
 
 	if (!headers.has('Accept')) {
 		headers.set('Accept', accept);
@@ -99,72 +107,6 @@ async function parseBody<T>(resp: Response, accept: MimeType): Promise<T> {
 	}
 }
 
-/**
- * Core fetch wrapper. All method helpers delegate to this.
- * @param url - Request URL
- * @param method - HTTP method
- * @param body - Request body (for POST/PUT/PATCH)
- * @param options - Request options
- * @returns Discriminated ApiResponse — check `ok` to narrow the type
- */
-async function request<T>(
-	url: string | URL,
-	method: HttpMethod,
-	body: BodyInit | undefined,
-	options: RequestBodyOptions = {}
-): Promise<ApiResponse<T>> {
-	const {
-		accept = MimeType.JSON,
-		contentType = MimeType.JSON,
-		compression,
-		headers: extraHeaders,
-		signal,
-	} = options;
-
-	try {
-		// Per RFC 9110 §9.3.1, GET requests MUST NOT have a body
-		const sendBody =
-			body != null && method !== HttpMethod.GET && method !== HttpMethod.HEAD
-				? compress(body, compression)
-				: null;
-
-		const headers = buildHeaders(
-			body != null ? contentType : undefined,
-			accept,
-			body != null ? compression : undefined,
-			extraHeaders,
-			body
-		);
-
-		const init: RequestInit = {
-			method,
-			body: sendBody,
-			headers,
-		};
-		if (signal != null) {
-			init.signal = signal;
-		}
-
-		const resp = await fetch(url, init);
-
-		if (!resp.ok) {
-			return { ok: false, data: null, status: resp.status };
-		}
-
-		// Per RFC 9110 §9.3.5, HEAD responses have no body; 204 means No Content.
-		if (method === HttpMethod.HEAD || resp.status === 204) {
-			return { ok: true, data: null, status: resp.status };
-		}
-
-		const data = await parseBody<T>(resp, accept);
-		return { ok: true, data, status: resp.status };
-	} catch (_error: unknown) {
-		// Network errors, aborts, and other client-side failures get status 0
-		// (not 500 — that would misrepresent a server error)
-		return { ok: false, data: null, status: 0 };
-	}
-}
-
 function serializeBody(body: unknown): BodyInit {
 	if (
 		body instanceof FormData ||
@@ -179,103 +121,205 @@ function serializeBody(body: unknown): BodyInit {
 	return JSON.stringify(body);
 }
 
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
- * RESTful API client with method helpers.
+ * Creates a configured API client.
  *
  * @example
  * ```ts
- * const result = await api.get<User[]>('/api/users');
+ * const api = createApi({
+ *   baseUrl: 'https://api.example.com',
+ *   headers: { Authorization: `Bearer ${token}` },
+ *   timeout: 5000,
+ * });
+ * const result = await api.get<User[]>('/users');
  * if (result.ok) {
  *   console.log(result.data); // User[]
  * }
  * ```
  */
-export const api = {
+export function createApi(config: ApiConfig = {}): ApiInstance {
 	/**
-	 * Sends a GET request.
+	 * Core fetch wrapper. All method helpers delegate to this.
 	 * @param url - Request URL
-	 * @param options - Request options (accept, headers, signal)
+	 * @param method - HTTP method
+	 * @param body - Request body (for POST/PUT/PATCH)
+	 * @param options - Request options
+	 * @returns Discriminated ApiResponse — check `ok` to narrow the type
 	 */
-	get<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>> {
-		return request<T>(url, HttpMethod.GET, undefined, options);
-	},
-
-	/**
-	 * Sends a POST request.
-	 * @param url - Request URL
-	 * @param body - Request body (auto-serialized to JSON if plain object)
-	 * @param options - Request options (contentType, accept, headers, signal, compression)
-	 */
-	post<T>(
+	async function request<T>(
 		url: string | URL,
-		body?: BodyInit | object,
-		options?: RequestBodyOptions
+		method: HttpMethod,
+		body?: BodyInit,
+		options: RequestBodyOptions = {}
 	): Promise<ApiResponse<T>> {
-		return request<T>(
-			url,
-			HttpMethod.POST,
-			body != null ? serializeBody(body) : undefined,
-			options
-		);
-	},
+		const {
+			accept = config.accept ?? MimeType.JSON,
+			contentType = MimeType.JSON,
+			compression,
+			headers: extraHeaders,
+			signal,
+			retry: maxRetries = 0,
+			retryDelay = 0,
+		} = options;
 
-	/**
-	 * Sends a PUT request.
-	 * @param url - Request URL
-	 * @param body - Request body (auto-serialized to JSON if plain object)
-	 * @param options - Request options (contentType, accept, headers, signal, compression)
-	 */
-	put<T>(
-		url: string | URL,
-		body?: BodyInit | object,
-		options?: RequestBodyOptions
-	): Promise<ApiResponse<T>> {
-		return request<T>(url, HttpMethod.PUT, body != null ? serializeBody(body) : undefined, options);
-	},
+		const resolvedUrl = config.baseUrl != null ? new URL(url, config.baseUrl) : url;
 
-	/**
-	 * Sends a PATCH request.
-	 * @param url - Request URL
-	 * @param body - Request body (auto-serialized to JSON if plain object)
-	 * @param options - Request options (contentType, accept, headers, signal, compression)
-	 */
-	patch<T>(
-		url: string | URL,
-		body?: BodyInit | object,
-		options?: RequestBodyOptions
-	): Promise<ApiResponse<T>> {
-		return request<T>(
-			url,
-			HttpMethod.PATCH,
-			body != null ? serializeBody(body) : undefined,
-			options
-		);
-	},
+		const effectiveTimeout = options.timeout ?? config.timeout;
+		const effectiveSignal =
+			signal != null && effectiveTimeout != null
+				? AbortSignal.any([signal, AbortSignal.timeout(effectiveTimeout)])
+				: effectiveTimeout != null
+					? AbortSignal.timeout(effectiveTimeout)
+					: signal;
 
-	/**
-	 * Sends a DELETE request.
-	 * @param url - Request URL
-	 * @param options - Request options (accept, headers, signal)
-	 */
-	delete<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>> {
-		return request<T>(url, HttpMethod.DELETE, undefined, options);
-	},
+		let attempt = 0;
+		while (true) {
+			try {
+				// Per RFC 9110 §9.3.1, GET requests MUST NOT have a body
+				const sendBody =
+					body != null && method !== HttpMethod.GET && method !== HttpMethod.HEAD
+						? compress(body, compression)
+						: null;
 
-	/**
-	 * Sends a HEAD request. Returns status and headers only (no body).
-	 * @param url - Request URL
-	 * @param options - Request options (headers, signal)
-	 */
-	head(url: string | URL, options?: RequestOptions): Promise<ApiResponse<null>> {
-		return request<null>(url, HttpMethod.HEAD, undefined, options);
-	},
+				const headers = buildHeaders(
+					body != null ? contentType : undefined,
+					accept,
+					body != null ? compression : undefined,
+					config.headers,
+					extraHeaders,
+					body
+				);
 
-	/**
-	 * Sends an OPTIONS request. Returns allowed methods and CORS info.
-	 * @param url - Request URL
-	 * @param options - Request options (accept, headers, signal)
-	 */
-	options<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>> {
-		return request<T>(url, HttpMethod.OPTIONS, undefined, options);
-	},
-};
+				const init: RequestInit = {
+					method,
+					body: sendBody,
+					headers,
+				};
+				if (effectiveSignal != null) {
+					init.signal = effectiveSignal;
+				}
+
+				const resp = await fetch(resolvedUrl, init);
+
+				if (!resp.ok) {
+					return { ok: false, data: null, status: resp.status };
+				}
+
+				// Per RFC 9110 §9.3.5, HEAD responses have no body; 204 means No Content.
+				if (method === HttpMethod.HEAD || resp.status === 204) {
+					return { ok: true, data: null, status: resp.status };
+				}
+
+				const data = await parseBody<T>(resp, accept);
+				return { ok: true, data, status: resp.status };
+			} catch (_error: unknown) {
+				// Network errors, aborts, and other client-side failures get status 0
+				// (not 500 — that would misrepresent a server error)
+				if (attempt >= maxRetries) {
+					return { ok: false, data: null, status: 0 };
+				}
+				attempt++;
+				if (retryDelay > 0) {
+					await sleep(retryDelay * 2 ** (attempt - 1));
+				}
+			}
+		}
+	}
+
+	return {
+		/**
+		 * Sends a GET request.
+		 * @param url - Request URL
+		 * @param options - Request options (accept, headers, signal, timeout, retry, retryDelay)
+		 */
+		get<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>> {
+			return request<T>(url, HttpMethod.GET, undefined, options);
+		},
+
+		/**
+		 * Sends a POST request.
+		 * @param url - Request URL
+		 * @param body - Request body (auto-serialized to JSON if plain object)
+		 * @param options - Request options (contentType, accept, headers, signal, compression, timeout, retry, retryDelay)
+		 */
+		post<T>(
+			url: string | URL,
+			body?: BodyInit | object,
+			options?: RequestBodyOptions
+		): Promise<ApiResponse<T>> {
+			return request<T>(
+				url,
+				HttpMethod.POST,
+				body != null ? serializeBody(body) : undefined,
+				options
+			);
+		},
+
+		/**
+		 * Sends a PUT request.
+		 * @param url - Request URL
+		 * @param body - Request body (auto-serialized to JSON if plain object)
+		 * @param options - Request options (contentType, accept, headers, signal, compression, timeout, retry, retryDelay)
+		 */
+		put<T>(
+			url: string | URL,
+			body?: BodyInit | object,
+			options?: RequestBodyOptions
+		): Promise<ApiResponse<T>> {
+			return request<T>(
+				url,
+				HttpMethod.PUT,
+				body != null ? serializeBody(body) : undefined,
+				options
+			);
+		},
+
+		/**
+		 * Sends a PATCH request.
+		 * @param url - Request URL
+		 * @param body - Request body (auto-serialized to JSON if plain object)
+		 * @param options - Request options (contentType, accept, headers, signal, compression, timeout, retry, retryDelay)
+		 */
+		patch<T>(
+			url: string | URL,
+			body?: BodyInit | object,
+			options?: RequestBodyOptions
+		): Promise<ApiResponse<T>> {
+			return request<T>(
+				url,
+				HttpMethod.PATCH,
+				body != null ? serializeBody(body) : undefined,
+				options
+			);
+		},
+
+		/**
+		 * Sends a DELETE request.
+		 * @param url - Request URL
+		 * @param options - Request options (accept, headers, signal, timeout, retry, retryDelay)
+		 */
+		delete<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>> {
+			return request<T>(url, HttpMethod.DELETE, undefined, options);
+		},
+
+		/**
+		 * Sends a HEAD request. Returns status and headers only (no body).
+		 * @param url - Request URL
+		 * @param options - Request options (headers, signal, timeout)
+		 */
+		head(url: string | URL, options?: RequestOptions): Promise<ApiResponse<null>> {
+			return request<null>(url, HttpMethod.HEAD, undefined, options);
+		},
+
+		/**
+		 * Sends an OPTIONS request. Returns allowed methods and CORS info.
+		 * @param url - Request URL
+		 * @param options - Request options (accept, headers, signal, timeout)
+		 */
+		options<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>> {
+			return request<T>(url, HttpMethod.OPTIONS, undefined, options);
+		},
+	};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
-export { api } from './api.ts';
+export { createApi } from './api.ts';
 export {
+	type ApiConfig,
+	type ApiInstance,
 	type ApiResponse,
 	CompressionMethod,
 	HttpMethod,

--- a/src/static.ts
+++ b/src/static.ts
@@ -114,6 +114,20 @@ export interface RequestOptions {
 	headers?: HeadersInit;
 	/** AbortSignal to cancel the request. */
 	signal?: AbortSignal;
+	/** Abort the request after this many milliseconds (raises a TimeoutError). */
+	timeout?: number;
+	/**
+	 * Maximum number of additional attempts on network failure (status 0).
+	 * Server responses (4xx, 5xx) are never retried — they are intentional responses.
+	 * Defaults to 0 (no retry).
+	 */
+	retry?: number;
+	/**
+	 * Base delay in milliseconds for exponential backoff between retry attempts.
+	 * Attempt 1 waits `retryDelay` ms, attempt 2 waits `retryDelay * 2` ms, etc.
+	 * Defaults to 0 (no delay).
+	 */
+	retryDelay?: number;
 }
 
 /** Options for requests that carry a body (POST, PUT, PATCH). */
@@ -131,3 +145,42 @@ export interface RequestBodyOptions extends RequestOptions {
 export type ApiResponse<T> =
 	| { ok: true; data: T | null; status: number }
 	| { ok: false; data: null; status: number };
+
+/**
+ * Configuration for a {@link createApi} instance.
+ * All fields are optional. Per-request options always take precedence over these defaults.
+ */
+export interface ApiConfig {
+	/** Base URL prepended to all relative request paths. Absolute URLs and URL
+	 *  instances bypass this automatically. */
+	baseUrl?: string | URL;
+	/** Default headers included in every request. Per-request headers take precedence. */
+	headers?: HeadersInit;
+	/** Default Accept MIME type for all requests. Defaults to {@link MimeType.JSON}. */
+	accept?: MimeType;
+	/** Default timeout in milliseconds for all requests. */
+	timeout?: number;
+}
+
+/** A configured API client returned by {@link createApi}. */
+export interface ApiInstance {
+	get<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>>;
+	post<T>(
+		url: string | URL,
+		body?: BodyInit | object,
+		options?: RequestBodyOptions
+	): Promise<ApiResponse<T>>;
+	put<T>(
+		url: string | URL,
+		body?: BodyInit | object,
+		options?: RequestBodyOptions
+	): Promise<ApiResponse<T>>;
+	patch<T>(
+		url: string | URL,
+		body?: BodyInit | object,
+		options?: RequestBodyOptions
+	): Promise<ApiResponse<T>>;
+	delete<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>>;
+	head(url: string | URL, options?: RequestOptions): Promise<ApiResponse<null>>;
+	options<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>>;
+}

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, mock } from 'bun:test';
-import { api, CompressionMethod, MimeType } from '../src/index.ts';
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { CompressionMethod, createApi, MimeType } from '../src/index.ts';
 
 const originalFetch = globalThis.fetch;
 
@@ -14,10 +14,12 @@ afterEach(() => {
 	globalThis.fetch = originalFetch;
 });
 
+const api = createApi();
+
 describe('api.head', () => {
 	it('returns ok with null data on 200', async () => {
 		// Arrange
-		setFetch(() => Promise.resolve(new Response(null, { status: 200 })));
+		setFetch(async () => new Response(null, { status: 200 }));
 
 		// Act
 		const result = await api.head('/ping');
@@ -32,7 +34,7 @@ describe('api.head', () => {
 describe('204 No Content', () => {
 	it('returns ok with null data regardless of method', async () => {
 		// Arrange
-		setFetch(() => Promise.resolve(new Response(null, { status: 204 })));
+		setFetch(async () => new Response(null, { status: 204 }));
 
 		// Act
 		const result = await api.post('/items', { name: 'test' });
@@ -47,13 +49,12 @@ describe('204 No Content', () => {
 describe('api.get', () => {
 	it('returns parsed JSON data on success', async () => {
 		// Arrange
-		setFetch(() =>
-			Promise.resolve(
+		setFetch(
+			async () =>
 				new Response(JSON.stringify({ id: 1, name: 'Alice' }), {
 					status: 200,
 					headers: { 'Content-Type': 'application/json' },
 				})
-			)
 		);
 
 		// Act
@@ -67,7 +68,7 @@ describe('api.get', () => {
 
 	it('returns ok: false with null data on error status', async () => {
 		// Arrange
-		setFetch(() => Promise.resolve(new Response(null, { status: 404 })));
+		setFetch(async () => new Response(null, { status: 404 }));
 
 		// Act
 		const result = await api.get('/missing');
@@ -93,11 +94,10 @@ describe('api.get', () => {
 
 	it('returns ok: false with status 0 on abort', async () => {
 		// Arrange
-		const controller = new AbortController();
 		setFetch(() => Promise.reject(new DOMException('The operation was aborted.', 'AbortError')));
 
 		// Act
-		const result = await api.get('/slow', { signal: controller.signal });
+		const result = await api.get('/slow', { signal: new AbortController().signal });
 
 		// Assert
 		expect(result.ok).toBe(false);
@@ -106,7 +106,7 @@ describe('api.get', () => {
 
 	it('returns text when accept is MimeType.PLAIN', async () => {
 		// Arrange
-		setFetch(() => Promise.resolve(new Response('hello world', { status: 200 })));
+		setFetch(async () => new Response('hello world', { status: 200 }));
 
 		// Act
 		const result = await api.get<string>('/readme', { accept: MimeType.PLAIN });
@@ -119,7 +119,7 @@ describe('api.get', () => {
 	it('returns a Blob for binary accept types', async () => {
 		// Arrange
 		const bytes = new Uint8Array([1, 2, 3]);
-		setFetch(() => Promise.resolve(new Response(bytes, { status: 200 })));
+		setFetch(async () => new Response(bytes, { status: 200 }));
 
 		// Act
 		const result = await api.get<Blob>('/file.bin', { accept: MimeType.OCTET_STREAM });
@@ -131,7 +131,7 @@ describe('api.get', () => {
 
 	it('accepts a URL instance as the url argument', async () => {
 		// Arrange
-		setFetch(() => Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })));
+		setFetch(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
 		// Act & Assert
 		const result = await api.get(new URL('https://example.com/api'));
@@ -142,7 +142,7 @@ describe('api.get', () => {
 describe('api.post', () => {
 	it('sends a plain object body and returns parsed JSON', async () => {
 		// Arrange
-		setFetch(() => Promise.resolve(new Response(JSON.stringify({ id: 42 }), { status: 201 })));
+		setFetch(async () => new Response(JSON.stringify({ id: 42 }), { status: 201 }));
 
 		// Act
 		const result = await api.post<{ id: number }>('/items', { name: 'widget' });
@@ -155,7 +155,7 @@ describe('api.post', () => {
 
 	it('accepts a pre-serialized string body', async () => {
 		// Arrange
-		setFetch(() => Promise.resolve(new Response(JSON.stringify({ id: 1 }), { status: 200 })));
+		setFetch(async () => new Response(JSON.stringify({ id: 1 }), { status: 200 }));
 
 		// Act
 		const result = await api.post('/items', JSON.stringify({ name: 'widget' }));
@@ -168,7 +168,7 @@ describe('api.post', () => {
 		// Arrange
 		const form = new FormData();
 		form.append('name', 'widget');
-		setFetch(() => Promise.resolve(new Response(JSON.stringify({ id: 1 }), { status: 200 })));
+		setFetch(async () => new Response(JSON.stringify({ id: 1 }), { status: 200 }));
 
 		// Act
 		const result = await api.post('/upload', form);
@@ -181,9 +181,7 @@ describe('api.post', () => {
 describe('api.put', () => {
 	it('returns parsed JSON on success', async () => {
 		// Arrange
-		setFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ id: 1, name: 'updated' }), { status: 200 }))
-		);
+		setFetch(async () => new Response(JSON.stringify({ id: 1, name: 'updated' }), { status: 200 }));
 
 		// Act
 		const result = await api.put<{ id: number; name: string }>('/items/1', { name: 'updated' });
@@ -197,9 +195,7 @@ describe('api.put', () => {
 describe('api.patch', () => {
 	it('returns parsed JSON on success', async () => {
 		// Arrange
-		setFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ id: 1, name: 'patched' }), { status: 200 }))
-		);
+		setFetch(async () => new Response(JSON.stringify({ id: 1, name: 'patched' }), { status: 200 }));
 
 		// Act
 		const result = await api.patch<{ id: number; name: string }>('/items/1', { name: 'patched' });
@@ -213,7 +209,7 @@ describe('api.patch', () => {
 describe('api.delete', () => {
 	it('returns ok with null data on 204', async () => {
 		// Arrange
-		setFetch(() => Promise.resolve(new Response(null, { status: 204 })));
+		setFetch(async () => new Response(null, { status: 204 }));
 
 		// Act
 		const result = await api.delete('/items/1');
@@ -228,9 +224,7 @@ describe('api.delete', () => {
 describe('api.options', () => {
 	it('returns parsed JSON on 200', async () => {
 		// Arrange
-		setFetch(() =>
-			Promise.resolve(new Response(JSON.stringify({ allow: 'GET, POST' }), { status: 200 }))
-		);
+		setFetch(async () => new Response(JSON.stringify({ allow: 'GET, POST' }), { status: 200 }));
 
 		// Act
 		const result = await api.options<{ allow: string }>('/items');
@@ -248,9 +242,9 @@ describe('compression', () => {
 		// Arrange
 		const form = new FormData();
 		form.append('name', 'widget');
-		setFetch((_, init) => {
+		setFetch(async (_, init) => {
 			capturedInit = init as RequestInit;
-			return Promise.resolve(new Response(null, { status: 204 }));
+			return new Response(null, { status: 204 });
 		});
 
 		// Act
@@ -263,9 +257,9 @@ describe('compression', () => {
 	it('passes URLSearchParams through unchanged when compressed', async () => {
 		// Arrange
 		const params = new URLSearchParams({ q: 'test' });
-		setFetch((_, init) => {
+		setFetch(async (_, init) => {
 			capturedInit = init as RequestInit;
-			return Promise.resolve(new Response(null, { status: 204 }));
+			return new Response(null, { status: 204 });
 		});
 
 		// Act
@@ -278,9 +272,9 @@ describe('compression', () => {
 	it('pipes a ReadableStream through CompressionStream', async () => {
 		// Arrange
 		const stream = new ReadableStream();
-		setFetch((_, init) => {
+		setFetch(async (_, init) => {
 			capturedInit = init as RequestInit;
-			return Promise.resolve(new Response(null, { status: 204 }));
+			return new Response(null, { status: 204 });
 		});
 
 		// Act
@@ -294,9 +288,9 @@ describe('compression', () => {
 	it('passes a small string through unchanged (below compression threshold)', async () => {
 		// Arrange
 		const small = 'x'.repeat(512);
-		setFetch((_, init) => {
+		setFetch(async (_, init) => {
 			capturedInit = init as RequestInit;
-			return Promise.resolve(new Response(null, { status: 204 }));
+			return new Response(null, { status: 204 });
 		});
 
 		// Act
@@ -309,9 +303,9 @@ describe('compression', () => {
 	it('compresses a large string into a ReadableStream and sets Content-Encoding header', async () => {
 		// Arrange
 		const large = 'x'.repeat(2000);
-		setFetch((_, init) => {
+		setFetch(async (_, init) => {
 			capturedInit = init as RequestInit;
-			return Promise.resolve(new Response(null, { status: 204 }));
+			return new Response(null, { status: 204 });
 		});
 
 		// Act
@@ -326,9 +320,9 @@ describe('compression', () => {
 	it('passes a small Blob through unchanged (below compression threshold)', async () => {
 		// Arrange
 		const blob = new Blob(['hello']);
-		setFetch((_, init) => {
+		setFetch(async (_, init) => {
 			capturedInit = init as RequestInit;
-			return Promise.resolve(new Response(null, { status: 204 }));
+			return new Response(null, { status: 204 });
 		});
 
 		// Act
@@ -341,9 +335,9 @@ describe('compression', () => {
 	it('passes a small ArrayBuffer through unchanged (below compression threshold)', async () => {
 		// Arrange
 		const buffer = new ArrayBuffer(16);
-		setFetch((_, init) => {
+		setFetch(async (_, init) => {
 			capturedInit = init as RequestInit;
-			return Promise.resolve(new Response(null, { status: 204 }));
+			return new Response(null, { status: 204 });
 		});
 
 		// Act
@@ -351,5 +345,268 @@ describe('compression', () => {
 
 		// Assert
 		expect(capturedInit?.body).toBe(buffer);
+	});
+});
+
+describe('timeout', () => {
+	it('returns ok: false with status 0 when request exceeds timeout', async () => {
+		// Arrange — fetch never resolves; AbortSignal.timeout fires
+		setFetch(
+			() =>
+				new Promise<Response>((_, reject) => {
+					// simulate a signal abort via the timeout mechanism
+					setTimeout(() => reject(new DOMException('Timeout', 'TimeoutError')), 50);
+				})
+		);
+
+		// Act
+		const result = await createApi().get('/slow', { timeout: 1 });
+
+		// Assert
+		expect(result.ok).toBe(false);
+		expect(result.status).toBe(0);
+	});
+
+	it('does not interfere with fast responses when timeout is generous', async () => {
+		// Arrange
+		setFetch(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+		// Act
+		const result = await createApi().get('/fast', { timeout: 10_000 });
+
+		// Assert
+		expect(result.ok).toBe(true);
+	});
+
+	it('applies config-level timeout to all requests', async () => {
+		// Arrange
+		const timedApi = createApi({ timeout: 1 });
+		setFetch(
+			() =>
+				new Promise<Response>((_, reject) => {
+					setTimeout(() => reject(new DOMException('Timeout', 'TimeoutError')), 50);
+				})
+		);
+
+		// Act
+		const result = await timedApi.get('/slow');
+
+		// Assert
+		expect(result.ok).toBe(false);
+		expect(result.status).toBe(0);
+	});
+
+	it('per-request timeout overrides config timeout', async () => {
+		// Arrange — config has short timeout, per-request overrides with generous value
+		const timedApi = createApi({ timeout: 1 });
+		setFetch(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+		// Act
+		const result = await timedApi.get('/fast', { timeout: 10_000 });
+
+		// Assert
+		expect(result.ok).toBe(true);
+	});
+});
+
+describe('retry', () => {
+	it('retries on network error up to retry count and returns ok: false', async () => {
+		// Arrange
+		let callCount = 0;
+		setFetch(() => {
+			callCount++;
+			return Promise.reject(new TypeError('Failed to fetch'));
+		});
+
+		// Act
+		const result = await createApi().get('/unreachable', { retry: 2 });
+
+		// Assert — 1 initial + 2 retries = 3 total
+		expect(result.ok).toBe(false);
+		expect(result.status).toBe(0);
+		expect(callCount).toBe(3);
+	});
+
+	it('does not retry on server errors (4xx/5xx)', async () => {
+		// Arrange
+		let callCount = 0;
+		setFetch(() => {
+			callCount++;
+			return Promise.resolve(new Response(null, { status: 500 }));
+		});
+
+		// Act
+		const result = await createApi().get('/server-error', { retry: 2 });
+
+		// Assert — server responded; no retry
+		expect(result.ok).toBe(false);
+		expect(result.status).toBe(500);
+		expect(callCount).toBe(1);
+	});
+
+	it('returns success immediately when an attempt succeeds before exhausting retries', async () => {
+		// Arrange — fail once then succeed
+		let callCount = 0;
+		setFetch(() => {
+			callCount++;
+			if (callCount === 1) {
+				return Promise.reject(new TypeError('Failed to fetch'));
+			}
+			return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+		});
+
+		// Act
+		const result = await createApi().get('/flaky', { retry: 2 });
+
+		// Assert
+		expect(result.ok).toBe(true);
+		expect(callCount).toBe(2);
+	});
+
+	it('uses exponential backoff between retry attempts', async () => {
+		// Arrange
+		const spy = spyOn(globalThis, 'setTimeout');
+		setFetch(() => Promise.reject(new TypeError('Failed to fetch')));
+
+		// Act
+		await createApi().get('/slow', { retry: 2, retryDelay: 100 });
+
+		// Assert — extract delays >= 100ms (ignoring internal timeouts) in call order
+		const delays = spy.mock.calls
+			.map(([, ms]) => ms)
+			.filter((ms): ms is number => typeof ms === 'number' && ms >= 100);
+
+		expect(delays[0]).toBe(100); // attempt 1: base
+		expect(delays[1]).toBe(200); // attempt 2: base * 2
+		spy.mockRestore();
+	});
+
+	it('does not retry by default (retry: 0)', async () => {
+		// Arrange
+		let callCount = 0;
+		setFetch(() => {
+			callCount++;
+			return Promise.reject(new TypeError('Failed to fetch'));
+		});
+
+		// Act
+		await createApi().get('/error');
+
+		// Assert
+		expect(callCount).toBe(1);
+	});
+});
+
+describe('createApi', () => {
+	it('prepends baseUrl to relative paths', async () => {
+		// Arrange
+		let capturedUrl: string | URL | undefined;
+		setFetch(async (input) => {
+			capturedUrl = input as URL;
+			return new Response(JSON.stringify({}), { status: 200 });
+		});
+		const client = createApi({ baseUrl: 'https://api.example.com' });
+
+		// Act
+		await client.get('/users');
+
+		// Assert
+		expect(capturedUrl?.toString()).toBe('https://api.example.com/users');
+	});
+
+	it('does not alter an absolute URL string even when baseUrl is set', async () => {
+		// Arrange
+		let capturedUrl: string | URL | undefined;
+		setFetch(async (input) => {
+			capturedUrl = input as URL;
+			return new Response(JSON.stringify({}), { status: 200 });
+		});
+		const client = createApi({ baseUrl: 'https://api.example.com' });
+
+		// Act
+		await client.get('https://other.example.com/data');
+
+		// Assert
+		expect(capturedUrl?.toString()).toBe('https://other.example.com/data');
+	});
+
+	it('accepts a URL instance as url argument when baseUrl is set', async () => {
+		// Arrange
+		let capturedUrl: string | URL | undefined;
+		setFetch(async (input) => {
+			capturedUrl = input as URL;
+			return new Response(JSON.stringify({}), { status: 200 });
+		});
+		const client = createApi({ baseUrl: 'https://api.example.com' });
+
+		// Act
+		await client.get(new URL('https://other.example.com/data'));
+
+		// Assert
+		expect(capturedUrl?.toString()).toBe('https://other.example.com/data');
+	});
+
+	it('includes config headers in every request', async () => {
+		// Arrange
+		let capturedHeaders: Headers | undefined;
+		setFetch(async (_, init) => {
+			capturedHeaders = init?.headers as Headers;
+			return new Response(JSON.stringify({}), { status: 200 });
+		});
+		const client = createApi({ headers: { 'X-Api-Key': 'secret' } });
+
+		// Act
+		await client.get('https://example.com/data');
+
+		// Assert
+		expect(capturedHeaders?.get('X-Api-Key')).toBe('secret');
+	});
+
+	it('per-request headers override config headers', async () => {
+		// Arrange
+		let capturedHeaders: Headers | undefined;
+		setFetch(async (_, init) => {
+			capturedHeaders = init?.headers as Headers;
+			return new Response(JSON.stringify({}), { status: 200 });
+		});
+		const client = createApi({ headers: { 'X-Api-Key': 'config-key' } });
+
+		// Act
+		await client.get('https://example.com/data', { headers: { 'X-Api-Key': 'request-key' } });
+
+		// Assert
+		expect(capturedHeaders?.get('X-Api-Key')).toBe('request-key');
+	});
+
+	it('applies config accept to all requests', async () => {
+		// Arrange
+		let capturedHeaders: Headers | undefined;
+		setFetch(async (_, init) => {
+			capturedHeaders = init?.headers as Headers;
+			return new Response('hello', { status: 200 });
+		});
+		const client = createApi({ accept: MimeType.PLAIN });
+
+		// Act
+		await client.get('https://example.com/text');
+
+		// Assert
+		expect(capturedHeaders?.get('Accept')).toBe(MimeType.PLAIN);
+	});
+
+	it('per-request accept overrides config accept', async () => {
+		// Arrange
+		let capturedHeaders: Headers | undefined;
+		setFetch(async (_, init) => {
+			capturedHeaders = init?.headers as Headers;
+			return new Response(JSON.stringify({}), { status: 200 });
+		});
+		const client = createApi({ accept: MimeType.PLAIN });
+
+		// Act
+		await client.get('https://example.com/json', { accept: MimeType.JSON });
+
+		// Assert
+		expect(capturedHeaders?.get('Accept')).toBe(MimeType.JSON);
 	});
 });


### PR DESCRIPTION
## Summary
- Replace exported `api` singleton with `createApi()` factory function
- Add `ApiConfig` for instance-level defaults (baseUrl, headers, accept, timeout)
- Add timeout support via `AbortSignal.timeout()` with signal combining
- Add retry with exponential backoff on network failures
- Add `ApiInstance` and `ApiConfig` type exports
- Rewrite README with full API reference
- Add timeout, retry, and createApi test coverage

## Fixes
Fixes #10
Fixes #11

## Test Plan
- [x] 39 tests pass (`bun test`)
- [x] Biome clean (`biome check .`)
- [x] TypeScript clean (`tsc --noEmit`)