### PR TITLE
fix(package): expand repository field to full object form

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
 	"author": "Colonel Jade <colonel.jade@proton.me> (https://github.com/coloneljade/)",
 	"license": "MIT",
 	"homepage": "https://github.com/coloneljade/auldrant-api#readme",
-	"repository": "github:coloneljade/auldrant-api",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/coloneljade/auldrant-api.git"
+	},
 	"bugs": {
 		"url": "https://github.com/coloneljade/auldrant-api/issues",
 		"email": "colonel.jade@proton.me"


### PR DESCRIPTION
## Summary
- Expands the `repository` shorthand string in `package.json` to a full object with `type` and `url` fields, silencing the npm auto-correct warning on publish

## Test Plan
- [ ] Verify no npm publish warning about repository field