### PR TITLE
ci: add CodeQL security analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,26 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

- Adds CodeQL analysis workflow for JavaScript/TypeScript
- Required by the `code_scanning` rule in the branch ruleset — CodeQL was listed as a required tool but no workflow existed to produce results

## Test plan

- [ ] CodeQL analysis runs successfully on this PR
- [ ] After merge, CodeQL produces results on main (needed before re-enabling the code_scanning ruleset rule)