### PR TITLE
fix(ci): bump codeql-action from v3 to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- Bump `github/codeql-action/init` and `github/codeql-action/analyze` from v3 to v4
- Resolves Node.js 20 deprecation warnings and v3 deprecation notice (Dec 2026)

## Test plan

- [ ] CodeQL analysis passes on this PR without Node.js deprecation warnings