### PR TITLE
fix: correct request semantics for typed arrays, retries, and parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.2] - 2026-04-21
+
+### Fixed
+
+- Correct request semantics for typed arrays, retries, and parse errors ([#36](https://github.com/coloneljade/auldrant-api/pull/36))
+
 ## [1.0.1] - 2026-03-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@auldrant/api",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Simple library for working with APIs",
 	"author": "Colonel Jade <colonel.jade@proton.me> (https://github.com/coloneljade/)",
 	"license": "MIT",

--- a/src/api.ts
+++ b/src/api.ts
@@ -118,6 +118,14 @@ function serializeBody(body: unknown): BodyInit {
 	) {
 		return body;
 	}
+	// ArrayBuffer.isView covers all TypedArrays and DataView. The narrow type is
+	// ArrayBufferView<ArrayBufferLike>, which is broader than BodyInit's
+	// ArrayBufferView<ArrayBuffer> (BodyInit excludes SharedArrayBuffer). fetch()
+	// already rejects SAB-backed views at runtime; the cast is safe for the
+	// documented BodyInit inputs.
+	if (ArrayBuffer.isView(body)) {
+		return body as BodyInit;
+	}
 	return JSON.stringify(body);
 }
 
@@ -165,58 +173,52 @@ export function createApi(config: ApiConfig = {}): ApiInstance {
 		} = options;
 
 		const resolvedUrl = config.baseUrl == null ? url : new URL(url, config.baseUrl);
-
 		const effectiveTimeout = options.timeout ?? config.timeout;
-		const effectiveSignal =
-			signal != null && effectiveTimeout != null
-				? AbortSignal.any([signal, AbortSignal.timeout(effectiveTimeout)])
-				: effectiveTimeout == null
-					? signal
-					: AbortSignal.timeout(effectiveTimeout);
 
 		let attempt = 0;
 		while (true) {
+			// Rebuild the signal each iteration so AbortSignal.timeout gets a fresh
+			// per-attempt budget; the caller's signal is reused by reference so a
+			// single abort still propagates.
+			const iterSignal =
+				signal != null && effectiveTimeout != null
+					? AbortSignal.any([signal, AbortSignal.timeout(effectiveTimeout)])
+					: effectiveTimeout == null
+						? signal
+						: AbortSignal.timeout(effectiveTimeout);
+
+			// Per RFC 9110 §9.3.1, GET requests MUST NOT have a body
+			const sendBody =
+				body != null && method !== HttpMethod.GET && method !== HttpMethod.HEAD
+					? compress(body, compression)
+					: null;
+
+			const headers = buildHeaders(
+				body == null ? undefined : contentType,
+				accept,
+				body == null ? undefined : compression,
+				config.headers,
+				extraHeaders,
+				body
+			);
+
+			const init: RequestInit = {
+				method,
+				body: sendBody,
+				headers,
+			};
+			if (iterSignal != null) {
+				init.signal = iterSignal;
+			}
+
+			let resp: Response;
 			try {
-				// Per RFC 9110 §9.3.1, GET requests MUST NOT have a body
-				const sendBody =
-					body != null && method !== HttpMethod.GET && method !== HttpMethod.HEAD
-						? compress(body, compression)
-						: null;
-
-				const headers = buildHeaders(
-					body == null ? undefined : contentType,
-					accept,
-					body == null ? undefined : compression,
-					config.headers,
-					extraHeaders,
-					body
-				);
-
-				const init: RequestInit = {
-					method,
-					body: sendBody,
-					headers,
-				};
-				if (effectiveSignal != null) {
-					init.signal = effectiveSignal;
+				resp = await fetch(resolvedUrl, init);
+			} catch {
+				// Caller-initiated abort short-circuits — the user said stop, so stop.
+				if (signal?.aborted === true) {
+					return { ok: false, data: null, status: 0 };
 				}
-
-				const resp = await fetch(resolvedUrl, init);
-
-				if (!resp.ok) {
-					return { ok: false, data: null, status: resp.status };
-				}
-
-				// Per RFC 9110 §9.3.5, HEAD responses have no body; 204 means No Content.
-				if (method === HttpMethod.HEAD || resp.status === 204) {
-					return { ok: true, data: null, status: resp.status };
-				}
-
-				const data = await parseBody<T>(resp, accept);
-				return { ok: true, data, status: resp.status };
-			} catch (_error: unknown) {
-				// Network errors, aborts, and other client-side failures get status 0
-				// (not 500 — that would misrepresent a server error)
 				if (attempt >= maxRetries) {
 					return { ok: false, data: null, status: 0 };
 				}
@@ -224,6 +226,26 @@ export function createApi(config: ApiConfig = {}): ApiInstance {
 				if (retryDelay > 0) {
 					await sleep(retryDelay * 2 ** (attempt - 1));
 				}
+				continue;
+			}
+
+			if (!resp.ok) {
+				return { ok: false, data: null, status: resp.status };
+			}
+
+			// Per RFC 9110 §9.3.5, HEAD responses have no body; 204 means No Content.
+			if (method === HttpMethod.HEAD || resp.status === 204) {
+				return { ok: true, data: null, status: resp.status };
+			}
+
+			// Parse failures mean the server responded but the body doesn't match
+			// `accept`. Return the actual status, not 0 (which means "no response"),
+			// and do not retry — another attempt will fail the same way.
+			try {
+				const data = await parseBody<T>(resp, accept);
+				return { ok: true, data, status: resp.status };
+			} catch {
+				return { ok: false, data: null, status: resp.status };
 			}
 		}
 	}

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -176,6 +176,38 @@ describe('api.post', () => {
 		// Assert
 		expect(result.ok).toBe(true);
 	});
+
+	it('sends Uint8Array bodies as-is, not JSON-stringified', async () => {
+		// Arrange
+		let captured: BodyInit | null | undefined;
+		setFetch(async (_, init) => {
+			captured = init?.body;
+			return new Response(null, { status: 204 });
+		});
+		const bytes = new Uint8Array([72, 105]);
+
+		// Act
+		await api.post('/bin', bytes);
+
+		// Assert
+		expect(captured).toBe(bytes);
+	});
+
+	it('sends DataView bodies as-is, not JSON-stringified', async () => {
+		// Arrange
+		let captured: BodyInit | null | undefined;
+		setFetch(async (_, init) => {
+			captured = init?.body;
+			return new Response(null, { status: 204 });
+		});
+		const view = new DataView(new ArrayBuffer(8));
+
+		// Act
+		await api.post('/bin', view);
+
+		// Assert
+		expect(captured).toBe(view);
+	});
 });
 
 describe('api.put', () => {
@@ -491,6 +523,94 @@ describe('retry', () => {
 
 		// Act
 		await createApi().get('/error');
+
+		// Assert
+		expect(callCount).toBe(1);
+	});
+
+	it('short-circuits when the caller signal is already aborted', async () => {
+		// Arrange
+		let callCount = 0;
+		setFetch(async (_, init) => {
+			callCount++;
+			if (init?.signal?.aborted) {
+				throw new DOMException('Aborted', 'AbortError');
+			}
+			return new Response(null, { status: 200 });
+		});
+		const controller = new AbortController();
+		controller.abort();
+
+		// Act
+		const result = await createApi().get('/x', {
+			signal: controller.signal,
+			retry: 3,
+			retryDelay: 0,
+		});
+
+		// Assert — caller said stop, stop immediately
+		expect(result.ok).toBe(false);
+		expect(result.status).toBe(0);
+		expect(callCount).toBeLessThanOrEqual(1);
+	});
+
+	it('retries timeouts with a fresh per-attempt signal', async () => {
+		// Arrange
+		let callCount = 0;
+		let sawAbortedOnEntry = false;
+		setFetch(async (_, init) => {
+			callCount++;
+			if (init?.signal?.aborted === true) {
+				sawAbortedOnEntry = true;
+			}
+			return new Promise<Response>((_, reject) => {
+				init?.signal?.addEventListener('abort', () => {
+					reject(new DOMException('Timeout', 'AbortError'));
+				});
+			});
+		});
+
+		// Act
+		await createApi().get('/slow', { timeout: 10, retry: 2, retryDelay: 0 });
+
+		// Assert — each attempt gets a fresh signal, so none arrive pre-aborted
+		expect(callCount).toBe(3);
+		expect(sawAbortedOnEntry).toBe(false);
+	});
+});
+
+describe('parse errors', () => {
+	it('reports the server status when a 2xx body cannot be parsed', async () => {
+		// Arrange — server returns HTML but the client asked for JSON
+		setFetch(
+			async () =>
+				new Response('<html>not json</html>', {
+					status: 200,
+					headers: { 'Content-Type': 'text/html' },
+				})
+		);
+
+		// Act
+		const result = await createApi().get('/x');
+
+		// Assert — status 0 would mean "no response"; the server did respond
+		expect(result.ok).toBe(false);
+		expect(result.status).toBe(200);
+	});
+
+	it('does not retry on a parse failure', async () => {
+		// Arrange
+		let callCount = 0;
+		setFetch(async () => {
+			callCount++;
+			return new Response('<html>bad</html>', {
+				status: 200,
+				headers: { 'Content-Type': 'text/html' },
+			});
+		});
+
+		// Act — server gave a deterministic response; retry would be pointless
+		await createApi().get('/x', { retry: 3 });
 
 		// Assert
 		expect(callCount).toBe(1);


### PR DESCRIPTION
### Fixed

- Typed arrays (Uint8Array, DataView, etc.) are now sent as bytes instead of JSON-stringified (Fixes #32)
- Retry loop now rebuilds AbortSignal per attempt, enabling fresh timeout budgets and properly handling caller-initiated aborts (Fixes #33)
- Response-body parse failures on 2xx responses now return the actual status code instead of 0, preventing retries against healthy servers (Fixes #34)

### Test Coverage

- Added comprehensive tests for typed array handling, per-attempt timeouts, caller abort short-circuit, and parse error semantics