### PR TITLE
feat: three-variant ApiResponse with empty discriminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0] - 2026-04-21
+
+### Added
+
+- Three-variant ApiResponse with empty discriminator ([#38](https://github.com/coloneljade/auldrant-api/pull/38))
+
 ## [1.0.2] - 2026-04-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ import { createApi } from '@auldrant/api';
 const api = createApi();
 
 const result = await api.get<User[]>('/api/users');
-if (result.ok) {
-  console.log(result.data); // User[]
-} else {
+if (result.ok && !result.empty) {
+  console.log(result.data); // User[] — no null check needed
+} else if (!result.ok) {
   console.error(result.status); // HTTP status code, or 0 for network errors
 }
 ```
@@ -46,7 +46,7 @@ Per-request options always override instance defaults.
 
 ## Method helpers
 
-All helpers are methods on the instance returned by `createApi` and return `Promise<ApiResponse<T>>`.
+All helpers are methods on the instance returned by `createApi`. Most return `Promise<ApiResponse<T>>`; `.head` returns `Promise<HeadResponse>` (HEAD responses are always empty).
 
 | Method | Signature |
 |--------|-----------|
@@ -64,11 +64,22 @@ Plain objects passed as `body` are automatically serialized to JSON.
 
 ```ts
 type ApiResponse<T> =
-  | { ok: true;  data: T | null; status: number }
-  | { ok: false; data: null;     status: number };
+  | { ok: true;  empty: false; data: T;    status: number }
+  | { ok: true;  empty: true;  data: null; status: number }
+  | { ok: false;               data: null; status: number };
 ```
 
-Use `ok` to narrow the type. Status `0` means a network error, timeout, or aborted request.
+Three variants, discriminated by `ok` and `empty`:
+
+| Check | `data` type | When |
+|-------|-------------|------|
+| `r.ok && !r.empty` | `T` | Success with body — the common case, no null check needed |
+| `r.ok && r.empty`  | `null` | 204 No Content, or HEAD response |
+| `!r.ok`            | `null` | Network failure, timeout, parse error, or non-2xx status |
+
+Status `0` means a network error, timeout, or aborted request. `head()` returns a narrower `HeadResponse` type — the non-empty success variant is omitted because HEAD responses never carry a body ([RFC 9110 §9.3.5][rfc-head]).
+
+[rfc-head]: https://www.rfc-editor.org/rfc/rfc9110#section-9.3.5
 
 ## Options reference
 
@@ -167,6 +178,7 @@ await api.post('/ingest', data, {
 | `ApiConfig` | type | Config object for `createApi` |
 | `ApiInstance` | type | Return type of `createApi` |
 | `ApiResponse` | type | Discriminated union response type |
+| `HeadResponse` | type | Response shape for HEAD requests (always `empty: true` on success) |
 | `RequestOptions` | type | Options for GET/DELETE/HEAD/OPTIONS |
 | `RequestBodyOptions` | type | Options for POST/PUT/PATCH |
 | `HttpMethod` | enum | GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@auldrant/api",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"description": "Simple library for working with APIs",
 	"author": "Colonel Jade <colonel.jade@proton.me> (https://github.com/coloneljade/)",
 	"license": "MIT",

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import {
 	type ApiInstance,
 	type ApiResponse,
 	type CompressionMethod,
+	type HeadResponse,
 	HttpMethod,
 	MimeType,
 	type RequestBodyOptions,
@@ -144,7 +145,7 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
  *   timeout: 5000,
  * });
  * const result = await api.get<User[]>('/users');
- * if (result.ok) {
+ * if (result.ok && !result.empty) {
  *   console.log(result.data); // User[]
  * }
  * ```
@@ -237,7 +238,7 @@ export function createApi(config: ApiConfig = {}): ApiInstance {
 
 			// Per RFC 9110 §9.3.5, HEAD responses have no body; 204 means No Content.
 			if (method === HttpMethod.HEAD || resp.status === 204) {
-				return { ok: true, data: null, status: resp.status };
+				return { ok: true, empty: true, data: null, status: resp.status };
 			}
 
 			// Parse failures mean the server responded but the body doesn't match
@@ -245,7 +246,7 @@ export function createApi(config: ApiConfig = {}): ApiInstance {
 			// and do not retry — another attempt will fail the same way.
 			try {
 				const data = await parseBody<T>(resp, accept);
-				return { ok: true, data, status: resp.status };
+				return { ok: true, empty: false, data, status: resp.status };
 			} catch {
 				return { ok: false, data: null, status: resp.status };
 			}
@@ -333,8 +334,8 @@ export function createApi(config: ApiConfig = {}): ApiInstance {
 		 * @param url - Request URL
 		 * @param options - Request options (headers, signal, timeout)
 		 */
-		head(url: string | URL, options?: RequestOptions): Promise<ApiResponse<null>> {
-			return request<null>(url, HttpMethod.HEAD, undefined, options);
+		head(url: string | URL, options?: RequestOptions): Promise<HeadResponse> {
+			return request<null>(url, HttpMethod.HEAD, undefined, options) as Promise<HeadResponse>;
 		},
 
 		/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
 	type ApiInstance,
 	type ApiResponse,
 	CompressionMethod,
+	type HeadResponse,
 	HttpMethod,
 	HttpStatus,
 	MimeType,

--- a/src/static.ts
+++ b/src/static.ts
@@ -143,11 +143,23 @@ export interface RequestBodyOptions extends RequestOptions {
 }
 
 /**
- * Discriminated union for API responses.
- * Use `ok` to narrow: if `ok` is true, `data` is `T`; otherwise `data` is `null`.
+ * Discriminated union for API responses. Narrow with `ok` and `empty`:
+ *
+ * - `r.ok && !r.empty` → `r.data` is `T` (success with body, the common case)
+ * - `r.ok && r.empty` → `r.data` is `null` (204 No Content or HEAD response)
+ * - `!r.ok` → `r.data` is `null` (network failure, timeout, parse error, or non-2xx)
  */
 export type ApiResponse<T> =
-	| { ok: true; data: T | null; status: number }
+	| { ok: true; empty: false; data: T; status: number }
+	| { ok: true; empty: true; data: null; status: number }
+	| { ok: false; data: null; status: number };
+
+/**
+ * Response shape for HEAD requests. HEAD responses never carry a body per
+ * RFC 9110 §9.3.5, so the success variant is always `empty: true`.
+ */
+export type HeadResponse =
+	| { ok: true; empty: true; data: null; status: number }
 	| { ok: false; data: null; status: number };
 
 /**
@@ -185,6 +197,6 @@ export interface ApiInstance {
 		options?: RequestBodyOptions
 	): Promise<ApiResponse<T>>;
 	delete<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>>;
-	head(url: string | URL, options?: RequestOptions): Promise<ApiResponse<null>>;
+	head(url: string | URL, options?: RequestOptions): Promise<HeadResponse>;
 	options<T>(url: string | URL, options?: RequestOptions): Promise<ApiResponse<T>>;
 }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -730,3 +730,72 @@ describe('createApi', () => {
 		expect(capturedHeaders?.get('Accept')).toBe(MimeType.JSON);
 	});
 });
+
+describe('response shape (three-variant union)', () => {
+	it('sets empty: false on success with body', async () => {
+		// Arrange
+		setFetch(
+			async () =>
+				new Response(JSON.stringify({ id: 1 }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				})
+		);
+
+		// Act
+		const result = await api.get<{ id: number }>('/users/1');
+
+		// Assert
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.empty).toBe(false);
+			if (!result.empty) {
+				// data narrows to { id: number } — no null check needed
+				expect(result.data.id).toBe(1);
+			}
+		}
+	});
+
+	it('sets empty: true on 204 No Content', async () => {
+		// Arrange
+		setFetch(async () => new Response(null, { status: 204 }));
+
+		// Act
+		const result = await api.post('/items', { name: 'test' });
+
+		// Assert
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.empty).toBe(true);
+			expect(result.data).toBeNull();
+		}
+	});
+
+	it('sets empty: true on HEAD response', async () => {
+		// Arrange
+		setFetch(async () => new Response(null, { status: 200 }));
+
+		// Act
+		const result = await api.head('/ping');
+
+		// Assert
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.empty).toBe(true);
+			expect(result.data).toBeNull();
+		}
+	});
+
+	it('omits empty on failure responses', async () => {
+		// Arrange
+		setFetch(async () => new Response(null, { status: 500 }));
+
+		// Act
+		const result = await api.get('/boom');
+
+		// Assert
+		expect(result.ok).toBe(false);
+		expect(result.data).toBeNull();
+		expect('empty' in result).toBe(false);
+	});
+});


### PR DESCRIPTION
Introduce a three-variant discriminated union for `ApiResponse<T>` that separates success-with-body, success-empty (204/HEAD), and failure cases using `ok` and `empty` flags.

### Added

- Three-variant ApiResponse type: `ok: true, empty: false` with `data: T`; `ok: true, empty: true` with `data: null`; `ok: false` with `data: null`
- HeadResponse type narrowed to always return `empty: true` on success per RFC 9110 §9.3.5
- Type narrowing pattern: `if (r.ok && !r.empty)` narrows to `data: T` without null checks

### Changed

- ApiResponse discriminator now uses both `ok` and `empty` flags instead of `ok` and `data: T | null`
- HEAD request handler returns HeadResponse instead of ApiResponse<null>

### Documentation

- Updated README examples to show `if (result.ok && !result.empty)` narrowing pattern
- Documented all three ApiResponse variants and HeadResponse type

## Test Plan

- [x] All 49 tests pass with 100% coverage
- [x] Type narrowing verified: `r.ok && !r.empty` gives `data: T`
- [x] HeadResponse omits non-empty success variant
- [x] 204 and HEAD responses emit `empty: true`
- [x] Build and format checks pass